### PR TITLE
docs: add issue templates, make generic

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -1,0 +1,56 @@
+---
+name: "🐞 Bug report"
+about: Report a bug.
+---
+<!--
+Hello! Thanks for taking an interest in Qri.
+
+Please search open and closed issues before submitting.
+
+Existing issues often contain information about workarounds, resolution, or progress updates.
+
+✂️ You can delete any html comments. ✂️
+
+Thanks for your help.
+
+-->
+## Environment
+<!-- ✂️ Delete any environment questions that do not apply to your issue. ✂️ -->
+
+### What is your OS and version?
+
+
+
+### What version of qri are you using (`qri version`)?
+
+
+
+### What version of Qri Desktop are you using?
+
+
+
+### What browser(s) did you use? What version?
+
+
+
+## Issue
+
+### What did you do?
+
+
+
+### What happened?
+
+
+
+### What did you expect to happen?
+
+
+
+<!-- Optional additional information. 
+     ✂️ Cut any that do not apply. -->
+
+### Please link any related issues.
+### Do you have a suggested fix?
+
+<!-- Thank you for your time. -->

--- a/.github/ISSUE_TEMPLATE/2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.md
@@ -1,0 +1,36 @@
+---
+name: "🚀 Feature request"
+about: Suggest a feature.
+---
+<!--
+Hello! Thanks for taking an interest in Qri.
+
+Please search open and closed issues before submitting.
+
+Existing issues often contain information about workarounds, resolution, or progress updates.
+
+✂️ You can delete any html comments. ✂️
+
+Thanks for your help.
+
+-->
+
+### What feature or capability would you like?
+
+
+
+### Do you have a proposed solution?
+
+
+
+### Have you considered any alternative solutions or workarounds?
+
+
+
+<!-- Optional additional information. 
+     ✂️ Cut any that do not apply. -->
+
+### Do you have any examples of similar features in other software?
+### Please link any related issues.
+
+<!-- Thank you for your time. -->

--- a/.github/ISSUE_TEMPLATE/3-support-request.md
+++ b/.github/ISSUE_TEMPLATE/3-support-request.md
@@ -1,0 +1,20 @@
+---
+name: "❓ Support request"
+about: Questions and requests for support.
+---
+
+      🛑          🛑          🛑
+
+Hello! Thanks for taking an interest in Qri.
+
+Please do not file questions or support requests on our issue tracker.
+
+Join us on Discord, we will be happy to help you.
+
+https://discord.com/invite/thkJHKj
+
+
+Qri team thanks you,
+and we look forward to chatting!
+
+      🛑          🛑          🛑

--- a/.github/ISSUE_TEMPLATE/4-security-issue.md
+++ b/.github/ISSUE_TEMPLATE/4-security-issue.md
@@ -1,0 +1,16 @@
+---
+name: "⚠️ Security issue"
+about: Report security issues to security@qri.io
+---
+
+      🛑          🛑          🛑
+
+STOP!
+
+Please do not file security issues on our issue tracker.
+
+For security vulnerabilities, send an email to security@qri.io
+
+Qri team thanks you.
+
+      🛑          🛑          🛑


### PR DESCRIPTION
edit bug report template to make `Environment` questions generic
add security issue template that points to security@qri.io

closes #4